### PR TITLE
feat: verify Azure upload and delete local backup

### DIFF
--- a/scripts/azcopy.sh
+++ b/scripts/azcopy.sh
@@ -22,4 +22,59 @@ fi
 
 # First argument is the backup file, the second is supposed to be the URL + SAS token
 # set as an environment variable.
-./azcopy copy $1 $AZCOPY
+# AIDEV-NOTE: upload, then verify blob exists AND size matches before deleting local file
+./azcopy copy "$1" "$AZCOPY"
+UPLOAD_EXIT_CODE=$?
+
+if [ $UPLOAD_EXIT_CODE -ne 0 ]; then
+    echo "ERROR: azcopy upload failed with exit code $UPLOAD_EXIT_CODE. Local file NOT deleted. [AZ-UPLOAD-FAIL]"
+    exit $UPLOAD_EXIT_CODE
+fi
+
+# Build the blob-specific URL: insert filename before the SAS query string
+FILENAME=$(basename "$1")
+CONTAINER_URL="${AZCOPY%%\?*}"
+SAS_TOKEN="${AZCOPY#*\?}"
+BLOB_URL="${CONTAINER_URL%/}/${FILENAME}?${SAS_TOKEN}"
+
+# Get local file size in bytes
+LOCAL_SIZE=$(stat --printf="%s" "$1" 2>/dev/null || stat -f "%z" "$1" 2>/dev/null)
+if [ -z "$LOCAL_SIZE" ]; then
+    echo "ERROR: Could not determine local file size. Local file NOT deleted. [AZ-LOCALSIZE-FAIL]"
+    exit 1
+fi
+
+# List the blob and check it exists with matching size
+LIST_OUTPUT=$(./azcopy list "$BLOB_URL" --machine-readable 2>&1)
+LIST_EXIT_CODE=$?
+
+if [ $LIST_EXIT_CODE -ne 0 ]; then
+    echo "ERROR: azcopy list failed (exit $LIST_EXIT_CODE). Cannot verify upload. Local file NOT deleted. [AZ-LIST-FAIL]"
+    echo "azcopy list output: $LIST_OUTPUT"
+    exit 1
+fi
+
+# Confirm filename appears in the listing
+if ! echo "$LIST_OUTPUT" | grep -q "$FILENAME"; then
+    echo "ERROR: Blob '$FILENAME' not found in Azure listing. Local file NOT deleted. [AZ-BLOBMISSING]"
+    echo "azcopy list output: $LIST_OUTPUT"
+    exit 1
+fi
+
+# Extract the Content Length from the listing and compare to local size
+REMOTE_SIZE=$(echo "$LIST_OUTPUT" | grep "$FILENAME" | grep -oP 'Content Length: \K[0-9]+' | head -1)
+if [ -z "$REMOTE_SIZE" ]; then
+    # Fallback: try alternate format (azcopy versions vary)
+    REMOTE_SIZE=$(echo "$LIST_OUTPUT" | grep "$FILENAME" | grep -oE '[0-9]+\.?[0-9]*\s*(B|KiB|MiB|GiB)' | head -1)
+    echo "WARNING: Could not parse exact byte size from azcopy list. Raw size info: $REMOTE_SIZE [AZ-SIZEPARSE-WARN]"
+    echo "Proceeding based on blob existence confirmation only."
+else
+    if [ "$REMOTE_SIZE" != "$LOCAL_SIZE" ]; then
+        echo "ERROR: Size mismatch! Local=$LOCAL_SIZE bytes, Remote=$REMOTE_SIZE bytes. Local file NOT deleted. [AZ-SIZEMISMATCH]"
+        exit 1
+    fi
+    echo "Size verified: $LOCAL_SIZE bytes (local) == $REMOTE_SIZE bytes (remote)"
+fi
+
+echo "Upload verified. Deleting local file: $1"
+rm -f "$1"

--- a/scripts/azcopy.sh
+++ b/scripts/azcopy.sh
@@ -26,7 +26,7 @@ fi
 ./azcopy copy "$1" "$AZCOPY"
 UPLOAD_EXIT_CODE=$?
 
-if [ $UPLOAD_EXIT_CODE -ne 0 ]; then
+if [ "$UPLOAD_EXIT_CODE" -ne 0 ]; then
     echo "ERROR: azcopy upload failed with exit code $UPLOAD_EXIT_CODE. Local file NOT deleted. [AZ-UPLOAD-FAIL]"
     exit $UPLOAD_EXIT_CODE
 fi


### PR DESCRIPTION
## Summary
- After `azcopy copy`, the script now verifies the blob landed in Azure before deleting the local backup file
- Three-layer verification: upload exit code, blob existence via `azcopy list`, and byte-level size comparison (`--machine-readable`)
- Every failure path preserves the local file and logs a unique grepable code (`[AZ-UPLOAD-FAIL]`, `[AZ-LIST-FAIL]`, `[AZ-BLOBMISSING]`, `[AZ-SIZEMISMATCH]`, etc.)
- Graceful fallback if exact byte size can't be parsed from `azcopy list` output (version differences)

## Test plan
- [ ] Run a backup and confirm the upload + verify + delete flow succeeds end-to-end
- [ ] Simulate upload failure (e.g., bad SAS token) and confirm local file is preserved
- [ ] Confirm size comparison works with `--machine-readable` output
- [ ] Test on both x86_64 and aarch64 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)